### PR TITLE
cassandra-autossh.service: Add a restart policy

### DIFF
--- a/deploy/cassandra-autossh.service
+++ b/deploy/cassandra-autossh.service
@@ -4,6 +4,8 @@ Description=AutoSSH for Cassandra
 [Service]
 User=glam
 Group=glam
+Restart=always
+RestartSec=15s
 ExecStart=/usr/bin/autossh -N wmflabs
  
 [Install]


### PR DESCRIPTION
In WMCZ's set up, the service failed for an unknown reason.
It is a good idea to restart the service whenever possible,
as unavailability of the ssh connection makes it impossible
for updates to work properly.